### PR TITLE
Improved API

### DIFF
--- a/src/docker_hub.ml
+++ b/src/docker_hub.ml
@@ -337,14 +337,14 @@ module Config = struct
     Json.pp fmt json
 end
 
-let fetch_rootfs ~output_dir {Manifest.rootfs_digest; _} {Token.token; name; _} =
+let fetch_rootfs ~output_file {Manifest.rootfs_digest; _} {Token.token; name; _} =
   match%lwt
     hurl ~meth:`GET
       ~headers:[("Accept", Manifest.rootfs_media_type); ("Authorization", fmt "Bearer %s" token)]
       (fmt "https://registry-1.docker.io/v2/%s/blobs/%s" name rootfs_digest)
   with
   | Ok x ->
-      Lwt_io.with_file ~mode:Lwt_io.Output (Fpath.to_string output_dir) begin fun ch ->
+      Lwt_io.with_file ~mode:Lwt_io.Output (Fpath.to_string output_file) begin fun ch ->
         let%lwt () = Lwt_io.write ch x in
         Lwt.return (Ok ())
       end

--- a/src/docker_hub.ml
+++ b/src/docker_hub.ml
@@ -12,6 +12,14 @@ type fetch_errors = [
 let fmt = Printf.sprintf
 let ( >>= ) = Result.bind
 
+(* TODO: Export that somewhere? It sounds useful *)
+let rec cmps = function
+  | [] -> 0
+  | f::fl ->
+      match f () with
+      | 0 -> cmps fl
+      | n -> n
+
 let hurl ~meth ~headers url =
   match%lwt
     Http_lwt_client.one_request
@@ -104,6 +112,15 @@ module Platform = struct
     arch : string;
     variant : string option;
   }
+
+  let compare {os; arch; variant} x =
+    cmps [
+      (fun () -> String.compare os x.os);
+      (fun () -> String.compare arch x.arch);
+      (fun () -> Option.compare String.compare variant x.variant);
+    ]
+
+  let equal x y = compare x y = 0
 end
 
 module Image = struct

--- a/src/docker_hub.ml
+++ b/src/docker_hub.ml
@@ -179,6 +179,14 @@ module Image = struct
   let ignore_digest image =
     let func_name = "Docker_hub.Image.ignore_digest" in
     Stdlib.fst (parse ~func_name image)
+
+  let to_string {name} {tag} = function
+    | None -> fmt "%s:%s" name tag
+    | Some {digest} -> fmt "%s:%s@%s" name tag digest
+
+  let name_to_string {name} = name
+  let tag_to_string {tag} = tag
+  let digest_to_string {digest} = digest
 end
 
 module Token = struct

--- a/src/docker_hub.ml
+++ b/src/docker_hub.ml
@@ -1,20 +1,16 @@
 (* SPDX-License-Identifier: MIT *)
 
+(* OCaml translation of a shell script found here: https://stackoverflow.com/a/37759182 *)
+(* More complete script also available here: https://github.com/moby/moby/blob/924edb948c2731df3b77697a8fcc85da3f6eef57/contrib/download-frozen-image-v2.sh *)
+
 type fetch_errors = [
   | `Api_error of Http_lwt_client.response * string option
   | `Malformed_json of string
   | `Msg of string
 ]
 
-type digest_errors = [
-  | `Malformed_json of string
-  | `No_corresponding_arch_found
-  | `No_corresponding_os_found
-]
-
-type t = Yojson.Safe.t list
-
 let fmt = Printf.sprintf
+let ( >>= ) = Result.bind
 
 let hurl ~meth ~headers url =
   match%lwt
@@ -28,94 +24,286 @@ let hurl ~meth ~headers url =
   | Ok (resp, body) -> Lwt.return (Error (`Api_error (resp, body)))
   | Error e -> Lwt.return (Error e)
 
-let json_get field = function
-  | `Assoc l -> List.find_map (fun (k, v) -> if String.equal k field then Some v else None) l
-  | _ -> None
+module Json : sig
+  type t
 
-let get_token ~repo =
+  val parse : string -> (t, [> `Malformed_json of string]) result
+
+  val get : string -> t -> (t, [> `Malformed_json of string]) result
+  val get_string : string -> t -> (string, [> `Malformed_json of string]) result
+  val get_list : string -> t -> (t list, [> `Malformed_json of string]) result
+  val get_string_list : string -> t -> (string list, [> `Malformed_json of string]) result
+
+  val get_string_opt : string -> t -> string option
+
+  val map :
+    (t -> ('a, [> `Malformed_json of string] as 'b) result) ->
+    t list ->
+    ('a list, [> `Malformed_json of string] as 'b) result
+
+  val pp : Format.formatter -> t -> unit
+end = struct
+  type t = Yojson.Safe.t
+
+  let parse json =
+    match Yojson.Safe.from_string json with
+    | json -> Ok json
+    | exception (Yojson.Json_error msg) -> Error (`Malformed_json msg)
+
+  let get field = function
+    | `Assoc l ->
+        begin match List.find_opt (fun (k, _) -> String.equal k field) l with
+        | Some (_, v) -> Ok v
+        | None -> Error (`Malformed_json field)
+        end
+    | _ -> Error (`Malformed_json field)
+
+  let get_opt field json =
+    match get field json with
+    | Ok x -> Some x
+    | Error _ -> None
+
+  let get_string field json =
+    get field json >>= function
+    | `String str -> Ok str
+    | _ -> Error (`Malformed_json field)
+
+  let get_string_opt field json =
+    match get_opt field json with
+    | Some (`String str) -> Some str
+    | _ -> None
+
+  let get_list field json =
+    get field json >>= function
+    | `List l -> Ok l
+    | _ -> Error (`Malformed_json field)
+
+  let map f l =
+    List.fold_left (fun acc x ->
+      acc >>= fun acc ->
+      f x >>= fun x ->
+      Ok (acc @ [x])
+    ) (Ok []) l
+
+  let get_string_list field json =
+    get field json >>= function
+    | `List l ->
+        map (function
+          | `String x -> Ok x
+          | _ -> Error (`Malformed_json "not a list of string")
+        ) l
+    | _ -> Error (`Malformed_json field)
+
+  let pp fmt json =
+    Yojson.Safe.pretty_print fmt json
+end
+
+module Platform = struct
+  type t = {
+    os : string;
+    arch : string;
+    variant : string option;
+  }
+end
+
+module Image = struct
+  type name = {name : string}
+  type tag = {tag : string}
+  type digest = {digest : string}
+
+  let parse ~func_name image =
+    (* TODO: Check the image argument for invalid characters *)
+    (* nameComponentRegexp restricts registry path component names to start
+       with at least one letter or number, with following parts able to be
+       separated by one period, one or two underscore and multiple dashes.
+       Source: https://stackoverflow.com/questions/43091075/docker-restrictions-regarding-naming-image *)
+    let fail () = raise (Invalid_argument func_name) in
+    let parse_name_and_tag image =
+      let parse_name image =
+        match String.split_on_char '/' image with
+        | [_; _] -> {name = image}
+        | [_] -> {name = "library/"^image}
+        | _ -> fail ()
+      in
+      match String.split_on_char ':' image with
+      | [image; tag] -> (parse_name image, {tag})
+      | [image] -> (parse_name image, {tag = "latest"})
+      | _ -> fail ()
+    in
+    match String.split_on_char '@' image with
+    | [image; digest] -> (parse_name_and_tag image, Some {digest})
+    | [image] -> (parse_name_and_tag image, None)
+    | _ -> fail ()
+
+  let with_digest image =
+    let func_name = "Docker_hub.Image.with_digest" in
+    match parse ~func_name image with
+    | (_, None) -> raise (Invalid_argument func_name)
+    | ((name, tag), Some digest) -> (name, tag, digest)
+
+  let without_digest image =
+    let func_name = "Docker_hub.Image.without_digest" in
+    match parse ~func_name image with
+    | (_, Some _) -> raise (Invalid_argument func_name)
+    | ((name, tag), None) -> (name, tag)
+
+  let ignore_digest image =
+    let func_name = "Docker_hub.Image.ignore_digest" in
+    Stdlib.fst (parse ~func_name image)
+end
+
+module Token = struct
+  type t = {
+    json : Json.t;
+    token : string;
+    name : string;
+  }
+
+  let fetch {Image.name} =
+    match%lwt
+      hurl ~meth:`GET
+        ~headers:[]
+        (fmt "https://auth.docker.io/token?service=registry.docker.io&scope=repository:%s:pull" name)
+    with
+    | Ok json ->
+        Lwt.return begin
+          Json.parse json >>= fun json ->
+          Json.get_string "token" json >>= fun token ->
+          Ok {json; token; name}
+        end
+    | Error e -> Lwt.return (Error e)
+
+  let pp fmt {json; token = _; name = _} =
+    Json.pp fmt json
+end
+
+let check_media_type media_type media_type' =
+  if String.equal media_type media_type' then
+    Ok ()
+  else
+    Error (`Malformed_json (fmt "mediaType: %s != %s" media_type media_type'))
+
+module Manifest = struct
+  type t = {
+    json : Json.t;
+    config_digest : string;
+    rootfs_digest : string;
+  }
+
+  let media_type = "application/vnd.docker.distribution.manifest.v2+json"
+  let config_media_type = "application/vnd.docker.container.image.v1+json"
+  let rootfs_media_type = "application/vnd.docker.image.rootfs.diff.tar.gzip"
+
+  let fetch {Image.digest} {Token.token; name; _} =
+    match%lwt
+      hurl ~meth:`GET
+        ~headers:[("Accept", media_type); ("Authorization", fmt "Bearer %s" token)]
+        (fmt "https://registry-1.docker.io/v2/%s/manifests/%s" name digest)
+    with
+    | Ok json ->
+        Lwt.return begin
+          Json.parse json >>= fun json ->
+          begin
+            Json.get "config" json >>= fun config ->
+            Json.get_string "mediaType" config >>= fun config_media_type' ->
+            check_media_type config_media_type config_media_type' >>= fun () ->
+            Json.get_string "digest" config
+          end >>= fun config_digest ->
+          begin
+            Json.get_list "layers" json >>= function
+            | [] | _::_::_ -> Error (`Msg "Does not support multiple layers yet") (* TODO *)
+            | [layer] ->
+                Json.get_string "mediaType" layer >>= fun rootfs_media_type' ->
+                check_media_type rootfs_media_type rootfs_media_type' >>= fun () ->
+                Json.get_string "digest" layer
+          end >>= fun rootfs_digest ->
+          Ok {json; config_digest; rootfs_digest}
+        end
+    | Error e -> Lwt.return (Error e)
+
+  let pp fmt {json; config_digest = _; rootfs_digest = _} =
+    Json.pp fmt json
+end
+
+module Manifests = struct
+  type elt = {
+    platform : Platform.t;
+    digest : Image.digest;
+  }
+
+  type t = {
+    json : Json.t;
+    elements : elt list;
+  }
+
+  let get_elt json =
+    Json.get_string "digest" json >>= fun digest ->
+    Json.get "platform" json >>= fun platform ->
+    Json.get_string "os" platform >>= fun os ->
+    Json.get_string "architecture" platform >>= fun arch ->
+    let variant = Json.get_string_opt "variant" platform in
+    let platform = {Platform.os; arch; variant} in
+    Ok {platform; digest = {Image.digest}}
+
+  let media_type = "application/vnd.docker.distribution.manifest.list.v2+json"
+
+  let fetch {Image.tag} {Token.token; name; _} =
+    match%lwt
+      hurl ~meth:`GET
+        ~headers:[("Accept", media_type); ("Authorization", fmt "Bearer %s" token)]
+        (fmt "https://registry-1.docker.io/v2/%s/manifests/%s" name tag)
+    with
+    | Ok json ->
+        Lwt.return begin
+          Json.parse json >>= fun json ->
+          Json.get_list "manifests" json >>= fun elements ->
+          Json.map get_elt elements >>= fun elements ->
+          Ok {json; elements}
+        end
+    | Error e -> Lwt.return (Error e)
+
+  let elements {elements; _} = elements
+
+  let pp fmt {json; elements = _} =
+    Json.pp fmt json
+end
+
+module Config = struct
+  type t = {
+    json : Json.t;
+    env : string list;
+    (* TODO: parse .architecture .os .variant *)
+  }
+
+  let fetch {Manifest.config_digest; _} {Token.token; name; _} =
+    match%lwt
+      hurl ~meth:`GET
+        ~headers:[("Accept", Manifest.config_media_type); ("Authorization", fmt "Bearer %s" token)]
+        (fmt "https://registry-1.docker.io/v2/%s/blobs/%s" name config_digest)
+    with
+  | Ok json ->
+      Lwt.return begin
+        Json.parse json >>= fun json ->
+        (Json.get "config" json >>= Json.get_string_list "Env") >>= fun env ->
+        Ok {json; env}
+      end
+  | Error e -> Lwt.return (Error e)
+
+  let env {env; _} = env
+
+  let pp fmt {json; env = _} =
+    Json.pp fmt json
+end
+
+let fetch_rootfs ~output_dir {Manifest.rootfs_digest; _} {Token.token; name; _} =
   match%lwt
     hurl ~meth:`GET
-      ~headers:[]
-      (fmt "https://auth.docker.io/token?service=registry.docker.io&scope=repository:%s:pull" repo)
+      ~headers:[("Accept", Manifest.rootfs_media_type); ("Authorization", fmt "Bearer %s" token)]
+      (fmt "https://registry-1.docker.io/v2/%s/blobs/%s" name rootfs_digest)
   with
-  | Ok token_json ->
-      let token_json = Yojson.Safe.from_string token_json in
-      begin match json_get "token" token_json with
-      | Some (`String token) -> Lwt.return (Ok token)
-      | _ -> Lwt.return (Error (`Malformed_json "token"))
+  | Ok x ->
+      Lwt_io.with_file ~mode:Lwt_io.Output (Fpath.to_string output_dir) begin fun ch ->
+        let%lwt () = Lwt_io.write ch x in
+        Lwt.return (Ok ())
       end
   | Error e -> Lwt.return (Error e)
-
-let rec find_manifest ~os ~arch = function
-  | manifest::manifests ->
-      begin match json_get "platform" manifest with
-      | Some platform ->
-          begin match json_get "os" platform with
-          | Some (`String os_) when String.equal os os_ ->
-              begin match json_get "architecture" platform with
-              | Some (`String arch_) when String.equal arch arch_ -> Ok manifest
-              | Some (`String _arch) -> find_manifest ~os ~arch manifests
-              | _ -> Error `No_corresponding_arch_found
-              end
-          | Some (`String _os) -> find_manifest ~os ~arch manifests
-          | _ -> Error `No_corresponding_os_found
-          end
-      | None -> Error (`Malformed_json "platform")
-      end
-  | [] -> Error (`Malformed_json "empty manifests")
-
-(* OCaml translation of a shell script found here: https://stackoverflow.com/a/37759182 *)
-(* More complete script also available here: https://github.com/moby/moby/blob/924edb948c2731df3b77697a8fcc85da3f6eef57/contrib/download-frozen-image-v2.sh *)
-let fetch_manifests ~repo ~tag =
-  (* TODO: Check the repo and tag arguments for invalid characters *)
-  (* nameComponentRegexp restricts registry path component names to start
-     with at least one letter or number, with following parts able to be
-     separated by one period, one or two underscore and multiple dashes.
-     Source: https://stackoverflow.com/questions/43091075/docker-restrictions-regarding-naming-image *)
-  let repo = match String.split_on_char '/' repo with
-    | [_; _] -> repo
-    | [_] -> "library/"^repo
-    | _ -> raise (Invalid_argument "Docker_hub.fetch_manifests ~repo")
-  in
-  let tag = Option.value tag ~default:"latest" in
-  match%lwt get_token ~repo with
-  | Ok token ->
-      let api = "application/vnd.docker.distribution.manifest.v2+json" in
-      let apil = "application/vnd.docker.distribution.manifest.list.v2+json" in
-      begin match%lwt
-        hurl ~meth:`GET
-          ~headers:[("Accept", api); ("Accept", apil); ("Authorization", fmt "Bearer %s" token)]
-          (fmt "https://registry-1.docker.io/v2/%s/manifests/%s" repo tag)
-      with
-      | Ok json ->
-          begin match Yojson.Safe.from_string json with
-          | json ->
-              begin match json_get "mediaType" json with
-              | Some (`String media_type) ->
-                  if String.equal media_type api then
-                    Lwt.return (Ok [json])
-                  else if String.equal media_type apil then
-                    match json_get "manifests" json with
-                    | Some (`List manifests) -> Lwt.return (Ok manifests)
-                    | _ -> Lwt.return (Error (`Malformed_json "no manifests"))
-                  else
-                    Lwt.return (Error (`Malformed_json "mediaType does not match request"))
-              | _ -> Lwt.return (Error (`Malformed_json "no mediaType"))
-              end
-          | exception (Yojson.Json_error msg) -> Lwt.return (Error (`Malformed_json msg))
-          end
-      | Error e -> Lwt.return (Error e)
-      end
-  | Error e -> Lwt.return (Error e)
-
-let pp fmt manifests =
-  Yojson.Safe.pretty_print fmt (`List manifests)
-
-let digest ~os ~arch manifests =
-  match find_manifest ~os ~arch manifests with
-  | Ok manifest ->
-      begin match json_get "digest" manifest with
-      | Some (`String digest) -> Ok digest
-      | _ -> Error (`Malformed_json "digest")
-      end
-  | Error e -> Error e

--- a/src/docker_hub.ml
+++ b/src/docker_hub.ml
@@ -164,6 +164,11 @@ module Image = struct
     | [image] -> (parse_name_and_tag image, None)
     | _ -> fail ~func_name
 
+  let from_string image =
+    let func_name = "Docker_hub.Image.from_string" in
+    let (name, tag), digest = parse ~func_name image in
+    (name, tag, digest)
+
   let with_digest image =
     let func_name = "Docker_hub.Image.with_digest" in
     match parse ~func_name image with

--- a/src/docker_hub.mli
+++ b/src/docker_hub.mli
@@ -82,7 +82,7 @@ module Config : sig
 end
 
 val fetch_rootfs :
-  output_dir:Fpath.t ->
+  output_file:Fpath.t ->
   Manifest.t ->
   Token.t ->
   (unit, [> fetch_errors]) result Lwt.t

--- a/src/docker_hub.mli
+++ b/src/docker_hub.mli
@@ -22,6 +22,12 @@ module Image : sig
   val with_digest : string -> name * tag * digest
   val without_digest : string -> name * tag
   val ignore_digest : string -> name * tag
+
+  val to_string : name -> tag -> digest option -> string
+
+  val name_to_string : name -> string
+  val tag_to_string : tag -> string
+  val digest_to_string : digest -> string
 end
 
 module Token : sig

--- a/src/docker_hub.mli
+++ b/src/docker_hub.mli
@@ -70,6 +70,7 @@ module Config : sig
     (t, [> fetch_errors]) result Lwt.t
 
   val env : t -> string list
+  val platform : t -> Platform.t
 
   val pp : Format.formatter -> t -> unit
 end

--- a/src/docker_hub.mli
+++ b/src/docker_hub.mli
@@ -6,23 +6,76 @@ type fetch_errors = [
   | `Msg of string
 ]
 
-type digest_errors = [
-  | `Malformed_json of string
-  | `No_corresponding_arch_found
-  | `No_corresponding_os_found
-]
+module Platform : sig
+  type t = {
+    os : string;
+    arch : string;
+    variant : string option;
+  }
+end
 
-type t
+module Image : sig
+  type name
+  type tag
+  type digest
 
-val fetch_manifests :
-  repo:string ->
-  tag:string option ->
-  (t, [> fetch_errors]) result Lwt.t
+  val with_digest : string -> name * tag * digest
+  val without_digest : string -> name * tag
+  val ignore_digest : string -> name * tag
+end
 
-val digest :
-  os:string ->
-  arch:string ->
-  t ->
-  (string, [> digest_errors]) result
+module Token : sig
+  type t
 
-val pp : Format.formatter -> t -> unit
+  val fetch : Image.name -> (t, [> fetch_errors]) result Lwt.t
+
+  val pp : Format.formatter -> t -> unit
+end
+
+module Manifest : sig
+  type t
+
+  val fetch :
+    Image.digest ->
+    Token.t ->
+    (t, [> fetch_errors]) result Lwt.t
+
+  val pp : Format.formatter -> t -> unit
+end
+
+module Manifests : sig
+  type t
+
+  type elt = {
+    platform : Platform.t;
+    digest : Image.digest;
+  }
+
+  val fetch :
+    Image.tag ->
+    Token.t ->
+    (t, [> fetch_errors]) result Lwt.t
+
+  val elements : t -> elt list
+
+  val pp : Format.formatter -> t -> unit
+end
+
+module Config : sig
+  type t
+
+  val fetch :
+    Manifest.t ->
+    Token.t ->
+    (t, [> fetch_errors]) result Lwt.t
+
+  val env : t -> string list
+
+  val pp : Format.formatter -> t -> unit
+end
+
+val fetch_rootfs :
+  output_dir:Fpath.t ->
+  Manifest.t ->
+  Token.t ->
+  (unit, [> fetch_errors]) result Lwt.t

--- a/src/docker_hub.mli
+++ b/src/docker_hub.mli
@@ -19,6 +19,7 @@ module Image : sig
   type tag
   type digest
 
+  val from_string : string -> name * tag * digest option
   val with_digest : string -> name * tag * digest
   val without_digest : string -> name * tag
   val ignore_digest : string -> name * tag

--- a/src/docker_hub.mli
+++ b/src/docker_hub.mli
@@ -12,6 +12,9 @@ module Platform : sig
     arch : string;
     variant : string option;
   }
+
+  val equal : t -> t -> bool
+  val compare : t -> t -> int
 end
 
 module Image : sig


### PR DESCRIPTION
Goal:
- [x] Get rid of the calls to docker in obuilder for FreeBSD (https://github.com/ocurrent/obuilder/pull/120)
- [ ] Have a high-level API (that fits obuilder and opam-health-check use-case)
- [x] Have a low-level API (for debug)

----- 
Hurdles:
- [ ] Currently http-lwt-client is bugged and can't be used (https://github.com/roburio/http-lwt-client/issues/12)